### PR TITLE
you should not need to configure the kubernetes master

### DIFF
--- a/src/etc/kubernetes/scdf-controller.yml
+++ b/src/etc/kubernetes/scdf-controller.yml
@@ -18,8 +18,6 @@ spec:
         ports:
         - containerPort: 9393
         env:
-        - name: KUBERNETES_MASTER
-          value: '<<URL-for-Kubernetes-master>>'
         - name: KUBERNETES_NAMESPACE
           value: 'default'
         - name: SPRING_APPLICATION_JSON


### PR DESCRIPTION
fabric8's kubernetes-client will read the kubernetes cluster from ~/.kube/config automatically when outside of kubernetes
or when inside kubernetes it will use the kubernetes service and ServiceAccount anyways - so should be zero configuration

Note if this is applied then you don't need folks to edit `src/etc/kubernetes/scdf-controller.yml` in step 6):
http://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/1.0.0.RC1/reference/html/_deploying_streams_on_kubernetes.html
