### PR TITLE
we can use the 'downward api` to default this

### DIFF
--- a/src/etc/kubernetes/scdf-controller.yml
+++ b/src/etc/kubernetes/scdf-controller.yml
@@ -21,6 +21,8 @@ spec:
         - name: KUBERNETES_MASTER
           value: '<<URL-for-Kubernetes-master>>'
         - name: KUBERNETES_NAMESPACE
-          value: 'default'
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.namespace"
         - name: SPRING_APPLICATION_JSON
           value: '{"spring.datasource.url":"jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT}/test","spring.datasource.driverClassName":"org.mariadb.jdbc.Driver","spring.datasource.username":"<<mysql-username>>","spring.datasource.password":"<<mysql-password>>","spring.datasource.testOnBorrow":true,"spring.datasource.validationQuery":"SELECT 1","spring.cloud.deployer.kubernetes.memory":"640Mi"}'


### PR DESCRIPTION
by using the `downward api` we can default the KUBERNETES_NAMESPACE env var to be the namespace where the ReplicationController is created to avoid the user having to configure this
