### PR TITLE
General ref. guide updates

### DIFF
--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
@@ -36,6 +36,12 @@ dataflow:>app register --type source --name time --uri docker://springcloudstrea
 but any app registered with a Maven, HTTP or File resource for the executable jar (using a `--uri` property prefixed with `maven://`, `http://` or `file://`) is *_not supported_*.
 ====
 
+=== Kubernetes Compatibility
+
+The Spring Cloud Data Flow implementation for Kubernetes uses link:https://github.com/spring-cloud/spring-cloud-deployer-kubernetes[Spring Cloud Deployer Kubernetes]
+library for orchestration. Before you begin setting up Kubermetes cluster, refer to the link:https://github.com/spring-cloud/spring-cloud-deployer-kubernetes#kubernetes-compatibility[compatibility-matrix]
+to learn more about the deployer/server compatibility against Kubernetes release versions.
+
 === Create a Kubernetes cluster
 
 The Kubernetes https://kubernetes.io/docs/setup/pick-right-solution/[Picking the Right Solution] guide lets you choose among many options so you can pick one that you are most comfortable using.
@@ -110,10 +116,17 @@ You can use the command `kubectl get all -l app=metrics` to verify that the depl
 +
 . Deploy Skipper
 +
-This is an optional step.  Deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] if you want the added features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features.
+Deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features.
 For more details, review the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[reference guide]
-for a complete overview and the feature capabilities.
-See the section <<getting-started-deploy-skipper>> for details.
+for a complete overview and the feature capabilities. Also, the <<getting-started-deploy-skipper>> section covers the internals
+in greater detail.
++
+Run the following commands to start Skipper as the companion server for Spring Cloud Data Flow:
++
+```
+$ kubectl create -f src/kubernetes/skipper/skipper-deployment.yaml
+$ kubectl create -f src/kubernetes/skipper/skipper-svc.yaml
+```
 +
 . Deploy the Data Flow Server.
 +
@@ -164,6 +177,7 @@ Use the `kubectl get svc scdf-server` command to locate the EXTERNAL_IP address 
 $ kubectl get svc
 NAME         CLUSTER-IP       EXTERNAL-IP       PORT(S)    AGE
 scdf-server  10.103.246.82    130.211.203.246   80/TCP     4m
+skipper      10.103.246.83    130.211.203.247   80/TCP     5m
 ```
 So the URL you need to use is in this case http://130.211.203.246
 +

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
@@ -116,12 +116,26 @@ You can use the command `kubectl get all -l app=metrics` to verify that the depl
 +
 . Deploy Skipper
 +
-Deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and rolling back Streams since Data Flow delegates to Skipper for those features.
-For more details, review the link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[reference guide]
-for a complete overview and the feature capabilities. Also, the <<getting-started-deploy-skipper>> section covers the internals
+Optionally, you can deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and
+rolling back Streams since Data Flow delegates to Skipper for those features. For more details, review Spring Cloud Skipper's
+link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[reference guide]
+for a complete overview and its feature capabilities. Also, the <<getting-started-deploy-skipper>> section covers the internals
 in greater detail.
 +
-Run the following commands to start Skipper as the companion server for Spring Cloud Data Flow:
+
+[NOTE]
+====
+To use Skipper, you _must_ uncomment the following properties in `src/kubernetes/skipper/skipper-deployment.yaml`.
+
+[source,yaml,options=nowrap]
+----
+
+# - name: SPRING_CLOUD_SKIPPER_CLIENT_URI
+#   value: 'http://${SKIPPER_SERVICE_HOST}/api'
+----
+====
++
+If you intend to use Skipper, run the following commands to start Skipper as the companion server for Spring Cloud Data Flow:
 +
 ```
 $ kubectl create -f src/kubernetes/skipper/skipper-deployment.yaml

--- a/src/kubernetes/server/server-deployment.yaml
+++ b/src/kubernetes/server/server-deployment.yaml
@@ -53,8 +53,9 @@ spec:
           value: 'http://${METRICS_SERVICE_HOST}'
         - name: SPRING_CLOUD_DATAFLOW_SERVER_URI
           value: 'http://${SCDF_SERVER_SERVICE_HOST}:${SCDF_SERVER_SERVICE_PORT}'
-        - name: SPRING_CLOUD_SKIPPER_CLIENT_URI  
-          value: 'http://${SKIPPER_SERVICE_HOST}/api'
+        # Uncomment the following properties if you're going to use Skipper for stream deployments
+        # - name: SPRING_CLOUD_SKIPPER_CLIENT_URI
+        #   value: 'http://${SKIPPER_SERVICE_HOST}/api'
           # Add Maven repo for metadata artifact resolution plus set metrics destination for all stream apps
         - name: SPRING_APPLICATION_JSON
           value: "{ \"maven\": { \"local-repository\": null, \"remote-repositories\": { \"repo1\": { \"url\": \"https://repo.spring.io/libs-snapshot\"} } }, \"spring.cloud.dataflow.application-properties.stream.spring.cloud.stream.bindings.applicationMetrics.destination\": \"metrics\" }"


### PR DESCRIPTION
This PR includes the following changes to the reference guide.

1) Remove the optionality of skipper deployment since the server deployment fails without it. [Resolves spring-cloud/spring-cloud-dataflow-server-kubernetes#247]
2) Instead of duplicating the compatibility matrix in the server docs, I'd want to suggest adding the reference to the matrix from k8s-deployer's README. [Resolves spring-cloud/spring-cloud-dataflow-server-kubernetes#249]