### PR TITLE
Remove SpringBoot version override

### DIFF
--- a/spring-cloud-dataflow-server-kubernetes/pom.xml
+++ b/spring-cloud-dataflow-server-kubernetes/pom.xml
@@ -12,17 +12,6 @@
 	<properties>
 		<start-class>org.springframework.cloud.dataflow.server.kubernetes.KubernetesDataFlowServer</start-class>
 	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-dependencies</artifactId>
-				<version>1.5.12.RELEASE</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
  Depends on spring-cloud/spring-cloud-dataflow#2285
  Currently set Boot version forces Maria 1.5.9 (as Spring 1.5.x dependency)