### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
-== Spring Cloud Data Flow - Kubernetes image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-K8SBMASTER[Build Status, link=https://build.spring.io/browse/SCD-K8SBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=ready&title=Ready[Stories in Ready, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes]
+== Spring Cloud Data Flow - Kubernetes image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-K8SBMASTER[Build Status, link=https://build.spring.io/browse/SCD-K8SBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=ready&title=Ready[Stories in Ready, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes]
 
 This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Data Flow]'s streaming and task/batch data pipelines to Kubernetes. This project builds upon an implementation of Spring Cloud Data Flow’s https://github.com/spring-cloud/spring-cloud-deployer[Deployer SPI] for Kubernetes.
 
-Please refer to the http://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/#_deploying_streams_on_kubernetes[reference documentation] on how to get started.
+Please refer to the https://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/#_deploying_streams_on_kubernetes[reference documentation] on how to get started.
 
 === Helm Chart
 

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/api-guide-link.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/api-guide-link.adoc
@@ -1,7 +1,7 @@
 // The API Guide adoc source file residing in SCDF core can't be included here, because it depends on generated
 // REST Docs snippets that aren't versionned (and are heavyweight to regenerate for each flavor). Hence, we do a
 // simple link to the correct SCDF core version:
-:spring-cloud-dataflow-docs-rest: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
+:spring-cloud-dataflow-docs-rest: https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
 
 [[api-guide]]
 = REST API Guide

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/appendix.adoc
@@ -5,8 +5,8 @@
 --
 Having trouble with Spring Cloud Data Flow, We'd like to help!
 
-* Ask a question - we monitor http://stackoverflow.com[stackoverflow.com] for questions
-  tagged with http://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
+* Ask a question - we monitor https://stackoverflow.com[stackoverflow.com] for questions
+  tagged with https://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
 * Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
 * Report bugs with Spring Cloud Data Flow for Kubernetes at https://github.com/spring-cloud/spring-cloud-dataflow-server-kubernetes/issues.
 --

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/configuration.adoc
@@ -169,7 +169,7 @@ Migration scripts for specific database types can be found in the https://github
 
 We are now securing the server application in the sample configurations file used in the <<kubernetes-getting-started,Getting Started section>>.
 
-This section covers the basic configuration settings we provide in the provided sample configuration, please refer to the  link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[core security documentation] for more detailed coverage of the security configuration options for the Spring Cloud Data Flow server and shell.
+This section covers the basic configuration settings we provide in the provided sample configuration, please refer to the  link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[core security documentation] for more detailed coverage of the security configuration options for the Spring Cloud Data Flow server and shell.
 
 The security settings in the `src/kubernetes/server/server-config-rabbit.yaml` file are:
 [source,yaml]

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
@@ -1,7 +1,7 @@
 [[kubernetes-getting-started]]
 = Getting Started
 
-http://cloud.spring.io/spring-cloud-dataflow/[Spring Cloud Data Flow] is a toolkit for building data integration and real-time data processing pipelines.
+https://cloud.spring.io/spring-cloud-dataflow/[Spring Cloud Data Flow] is a toolkit for building data integration and real-time data processing pipelines.
 
 Pipelines consist of Spring Boot apps, built using the Spring Cloud Stream or Spring Cloud Task microservice frameworks. This makes Spring Cloud Data Flow suitable for a range of data processing use cases, from import/export to event streaming and predictive analytics.
 
@@ -50,7 +50,7 @@ All our testing is done using the https://cloud.google.com/kubernetes-engine/[Go
 
 NOTE: When starting Minikube you should allocate some extra resources since we will be deploying several services. We have used `minikube start --cpus=4 --memory=4096` to start.
 
-The rest of this getting started guide assumes that you have a working Kubernetes cluster and a `kubectl` command line utility. See the docs for installation instructions: http://kubernetes.io/docs/user-guide/prereqs/[Installing and Setting up kubectl].
+The rest of this getting started guide assumes that you have a working Kubernetes cluster and a `kubectl` command line utility. See the docs for installation instructions: https://kubernetes.io/docs/user-guide/prereqs/[Installing and Setting up kubectl].
 
 
 === Deploying using kubectl
@@ -116,7 +116,7 @@ You can use the command `kubectl get all -l app=metrics` to verify that the depl
 +
 . Deploy Skipper
 +
-Optionally, you can deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and
+Optionally, you can deploy link:https://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and
 rolling back Streams since Data Flow delegates to Skipper for those features. For more details, review Spring Cloud Skipper's
 link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[reference guide]
 for a complete overview and its feature capabilities.
@@ -195,7 +195,7 @@ To use Skipper, you _must_ uncomment the following properties to `src/kubernetes
 ----
 ====
 +
-The Data Flow Server uses the https://github.com/fabric8io/kubernetes-client[Fabric8 Java client library] to connect to the Kubernetes cluster.  We are using environment variables to set the values needed when deploying the Data Flow server to Kubernetes. We are also using the https://github.com/fabric8io/spring-cloud-kubernetes[Fabric8 Spring Cloud integration with Kubernetes library] to access Kubernetes http://kubernetes.io/docs/user-guide/configmap/[ConfigMap] and http://kubernetes.io/docs/user-guide/secrets/[Secrets] settings.
+The Data Flow Server uses the https://github.com/fabric8io/kubernetes-client[Fabric8 Java client library] to connect to the Kubernetes cluster.  We are using environment variables to set the values needed when deploying the Data Flow server to Kubernetes. We are also using the https://github.com/fabric8io/spring-cloud-kubernetes[Fabric8 Spring Cloud integration with Kubernetes library] to access Kubernetes https://kubernetes.io/docs/user-guide/configmap/[ConfigMap] and https://kubernetes.io/docs/user-guide/secrets/[Secrets] settings.
 The ConfigMap settings are specified in the `src/kubernetes/server/server-config-rabbit.yaml` file and the secrets are in the `src/kubernetes/mysql/mysql-secrets.yaml` file. If you modified the password for MySQL you should have changed it in the `src/kubernetes/mysql/mysql-secrets.yaml` file. Any secrets have to be provided base64 encoded.
 +
 NOTE: We are now configuring the Data Flow server with file based security and the default user is 'user' with a password of 'password'. Feel free to change this in the `src/kubernetes/server/server-config-rabbit.yaml` file.
@@ -228,13 +228,13 @@ $ kubectl get svc scdf-server
 NAME         CLUSTER-IP       EXTERNAL-IP       PORT(S)    AGE
 scdf-server  10.103.246.82    130.211.203.246   80/TCP     4m
 ```
-So the URL you need to use is in this case http://130.211.203.246
+So the URL you need to use is in this case https://130.211.203.246
 +
 If you are using Minikube then you don't have an external load balancer and the EXTERNAL-IP will show as `<pending>`. You need to use the NodePort assigned for the `scdf-server` service. Use this command to look up the URL to use:
 +
 ```
 $ minikube service --url scdf-server
-http://192.168.99.100:31991
+https://192.168.99.100:31991
 ```
 
 == Helm Installation
@@ -437,7 +437,7 @@ helm install --name my-release \
 +
 [subs=attributes]
 ```
-wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+wget https://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 
 $ java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ```
@@ -466,8 +466,8 @@ server-unknown:>
 Configure the Data Flow server URI with the following command (use the URL determined above in the previous step) using the default user and password settings:
 +
 ```
-server-unknown:>dataflow config server --username user --password password --uri http://130.211.203.246/
-Successfully targeted http://130.211.203.246/
+server-unknown:>dataflow config server --username user --password password --uri https://130.211.203.246/
+Successfully targeted https://130.211.203.246/
 dataflow:>
 ```
 +
@@ -480,7 +480,7 @@ dataflow:>app register --type sink --name log --uri docker://springcloudstream/l
 ```
 +
 . Alternatively, if you would like to register all out-of-the-box stream applications built with the Rabbit binder in bulk,
-you can with the following command. For more details, review how to link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/spring-cloud-dataflow-register-apps.html[register applications].
+you can with the following command. For more details, review how to link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/spring-cloud-dataflow-register-apps.html[register applications].
 +
 ```
 dataflow:>app import --uri https://bit.ly/Celsius-SR2-stream-applications-rabbit-docker
@@ -592,13 +592,13 @@ Now look up the URL to use with the following command:
 ```
 dataflow:>! minikube service --url test-http
 command is:minikube service --url test-http
-http://192.168.99.100:32123
+https://192.168.99.100:32123
 ```
 +
 . Post some data to the `test-http` app either using the EXTERNAL-IP address from above with port 8080 or the URL provided by the minikube command:
 +
 ```
-dataflow:>http post --target http://130.211.200.96:8080 --data "Hello"
+dataflow:>http post --target https://130.211.200.96:8080 --data "Hello"
 ```
 +
 . Finally, look at the logs for the `test-log` pod:

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/howto.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/howto.adoc
@@ -8,7 +8,7 @@ This section provides answers to some common '`how do I do that...`' type of que
 that often arise when using Spring Cloud Data Flow. 
 
 If you are having a specific problem that we don't cover here, you might want to check out
-http://stackoverflow.com/tags/spring-cloud-dataflow[stackoverflow.com] to see if someone has
+https://stackoverflow.com/tags/spring-cloud-dataflow[stackoverflow.com] to see if someone has
 already provided an answer; this is also a great place to ask new questions (please use
 the `spring-cloud-dataflow` tag).
 
@@ -19,7 +19,7 @@ can send us a {github-code}[pull request].
 === Logging
 
 Spring Cloud Data Flow is built upon several Spring projects, but ultimately the dataflow-server is a 
-Spring Boot app, so the logging techniques that apply to any link:http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-logging[Spring Boot]
+Spring Boot app, so the logging techniques that apply to any link:https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-logging[Spring Boot]
 application are applicable here as well.
 
 

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/index.adoc
@@ -30,9 +30,9 @@ Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinat
 :docker-timestamp-task-version: 1.3.0.RELEASE
 :skipper-core-version: 1.0.7.RELEASE
 
-:spring-cloud-dataflow-docs: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference
+:spring-cloud-dataflow-docs: https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference
 :github-repo: spring-cloud/spring-cloud-dataflow-server-kubernetes
-:github-code: http://github.com/{github-repo}
+:github-code: https://github.com/{github-repo}
 :dataflow-asciidoc: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/{scdf-core-git}/spring-cloud-dataflow-docs/src/main/asciidoc
 
 ifdef::backend-html5[]

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/streams-skipper.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/streams-skipper.adoc
@@ -33,21 +33,21 @@ $ kubectl get svc scdf-server
 NAME         CLUSTER-IP       EXTERNAL-IP       PORT(S)    AGE
 scdf-server  10.103.246.82    130.211.203.246   80/TCP     4m
 ```
-So the URL you need to use is in this case http://130.211.203.246
+So the URL you need to use is in this case https://130.211.203.246
 
 If you are using Minikube then you don't have an external load balancer and the EXTERNAL-IP will show as `<pending>`. You need to use the NodePort assigned for the `skipper` service. Use this command to look up the URL to use:
 
 ```
 $ minikube service --url scdf-server
-http://192.168.99.100:31991
+https://192.168.99.100:31991
 ```
 
 Configure the Data Flow server URI with the following command using the default user and password settings:
 
 [source,console,options=nowrap]
 ----
-server-unknown:>dataflow config server --username user --password password --uri http://130.211.203.246
-Successfully targeted http://130.211.203.246
+server-unknown:>dataflow config server --username user --password password --uri https://130.211.203.246
+Successfully targeted https://130.211.203.246
 dataflow:>
 ----
 Alternatively, pass in the command line option `--dataflow.uri`.  The shell's command line option `--help` shows what is available.

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://130.211.203.246/ (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://130.211.203.246/ ([https](https://130.211.203.246/) result AnnotatedConnectException).
* [ ] http://130.211.200.96:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://130.211.200.96:8080 ([https](https://130.211.200.96:8080) result ConnectTimeoutException).
* [ ] http://130.211.203.246 (ConnectTimeoutException) with 4 occurrences migrated to:  
  https://130.211.203.246 ([https](https://130.211.203.246) result ConnectTimeoutException).
* [ ] http://192.168.99.100:31991 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.99.100:31991 ([https](https://192.168.99.100:31991) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32123 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32123 ([https](https://192.168.99.100:32123) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-dataflow/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-dataflow/ ([https](https://cloud.spring.io/spring-cloud-dataflow/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-skipper/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-skipper/ ([https](https://cloud.spring.io/spring-cloud-skipper/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/) result 200).
* [ ] http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/tags/spring-cloud-dataflow with 2 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-cloud-dataflow ([https](https://stackoverflow.com/tags/spring-cloud-dataflow) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes ([https](https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes) result 200).
* [ ] http://kubernetes.io/docs/user-guide/configmap/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/configmap/ ([https](https://kubernetes.io/docs/user-guide/configmap/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/prereqs/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/prereqs/ ([https](https://kubernetes.io/docs/user-guide/prereqs/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/secrets/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/secrets/ ([https](https://kubernetes.io/docs/user-guide/secrets/) result 301).
* [ ] http://repo.spring.io/ with 1 occurrences migrated to:  
  https://repo.spring.io/ ([https](https://repo.spring.io/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8761/eureka/ with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences