### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
-== Spring Cloud Data Flow - Kubernetes image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-K8SBMASTER[Build Status, link=https://build.spring.io/browse/SCD-K8SBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=ready&title=Ready[Stories in Ready, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes]
+== Spring Cloud Data Flow - Kubernetes image:https://build.spring.io/plugins/servlet/wittified/build-status/SCD-K8SBMASTER[Build Status, link=https://build.spring.io/browse/SCD-K8SBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=ready&title=Ready[Stories in Ready, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes]
 
 This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Data Flow]'s streaming and task/batch data pipelines to Kubernetes. This project builds upon an implementation of Spring Cloud Data Flow’s https://github.com/spring-cloud/spring-cloud-deployer[Deployer SPI] for Kubernetes.
 
-Please refer to the http://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/#_deploying_streams_on_kubernetes[reference documentation] on how to get started.
+Please refer to the https://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/#_deploying_streams_on_kubernetes[reference documentation] on how to get started.
 
 === Helm Chart
 

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/api-guide-link.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/api-guide-link.adoc
@@ -1,7 +1,7 @@
 // The API Guide adoc source file residing in SCDF core can't be included here, because it depends on generated
 // REST Docs snippets that aren't versionned (and are heavyweight to regenerate for each flavor). Hence, we do a
 // simple link to the correct SCDF core version:
-:spring-cloud-dataflow-docs-rest: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
+:spring-cloud-dataflow-docs-rest: https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/index.html#api-guide
 
 [[api-guide]]
 = REST API Guide

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/appendix.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/appendix.adoc
@@ -5,8 +5,8 @@
 --
 Having trouble with Spring Cloud Data Flow? We want to help!
 
-* Ask a question. We monitor http://stackoverflow.com[stackoverflow.com] for questions
-  tagged with http://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
+* Ask a question. We monitor https://stackoverflow.com[stackoverflow.com] for questions
+  tagged with https://stackoverflow.com/tags/spring-cloud-dataflow[`spring-cloud-dataflow`].
 * Report bugs with Spring Cloud Data Flow at https://github.com/spring-cloud/spring-cloud-dataflow/issues.
 * Report bugs with Spring Cloud Data Flow for Kubernetes at https://github.com/spring-cloud/spring-cloud-dataflow-server-kubernetes/issues.
 --

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/configuration.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/configuration.adoc
@@ -178,7 +178,7 @@ You can find migration scripts for specific database types in the https://github
 
 This section covers how to secure the server application in the sample configurations file used in <<kubernetes-getting-started>>.
 
-This section covers the basic configuration settings in the sample configuration. See the  link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[core security documentation] for more detailed coverage of the security configuration options for the Spring Cloud Data Flow server and shell.
+This section covers the basic configuration settings in the sample configuration. See the  link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/htmlsingle/#configuration-security[core security documentation] for more detailed coverage of the security configuration options for the Spring Cloud Data Flow server and shell.
 
 When using RabbitMQ as the transport, the security settings are located in the `src/kubernetes/server/server-config-rabbit.yaml` file. For Kafka, the settings are located in the `src/kubernetes/server/server-config-kafka.yaml` file. The following example shows a security configuration in YAML:
 

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/getting-started.adoc
@@ -1,7 +1,7 @@
 [[kubernetes-getting-started]]
 = Getting Started
 
-http://cloud.spring.io/spring-cloud-dataflow/[Spring Cloud Data Flow] is a toolkit for building data integration and real-time data-processing pipelines.
+https://cloud.spring.io/spring-cloud-dataflow/[Spring Cloud Data Flow] is a toolkit for building data integration and real-time data-processing pipelines.
 
 Pipelines consist of Spring Boot apps, built with the Spring Cloud Stream or Spring Cloud Task microservice frameworks. This makes Spring Cloud Data Flow suitable for a range of data-processing use cases, from import-export to event-streaming and predictive analytics.
 
@@ -58,7 +58,7 @@ All our testing is done with the https://cloud.google.com/kubernetes-engine/[Goo
 
 NOTE: When starting Minikube, you should allocate some extra resources, since we deploy several services. We start with `minikube start --cpus=4 --memory=4096`. Please note that the allocated memory and cpu for the Minikube VM directly gets assigned to the number of applications deployed in a stream/task. The more you add, the more VM resources is required.
 
-The rest of this getting started guide assumes that you have a working Kubernetes cluster and a `kubectl` command line utility. See the docs for installation instructions: http://kubernetes.io/docs/user-guide/prereqs/[Installing and Setting up kubectl].
+The rest of this getting started guide assumes that you have a working Kubernetes cluster and a `kubectl` command line utility. See the docs for installation instructions: https://kubernetes.io/docs/user-guide/prereqs/[Installing and Setting up kubectl].
 
 === Deploying with `kubectl`
 
@@ -171,7 +171,7 @@ You can use `kubectl get all -l app=metrics` to verify that the deployment, pod,
 +
 . Deploy Skipper (optional, recommended)
 +
-Optionally, you can deploy link:http://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and
+Optionally, you can deploy link:https://cloud.spring.io/spring-cloud-skipper/[Skipper] to leverage the features of upgrading and
 rolling back Streams, since Data Flow delegates to Skipper for those features. For more details, see
 link:https://docs.spring.io/spring-cloud-skipper/docs/{skipper-core-version}/reference/htmlsingle/#overview[Spring Cloud Skipper Reference Guide]
 for a complete overview.
@@ -265,7 +265,7 @@ To use Skipper, you must uncomment the following properties in `src/kubernetes/s
 ====
 =====
 +
-The Data Flow Server uses the https://github.com/fabric8io/kubernetes-client[Fabric8 Java client library] to connect to the Kubernetes cluster. We use environment variables to set the values needed when deploying the Data Flow server to Kubernetes. We also use the https://github.com/fabric8io/spring-cloud-kubernetes[Fabric8 Spring Cloud integration with Kubernetes library] to access the Kubernetes http://kubernetes.io/docs/user-guide/configmap/[ConfigMap] and http://kubernetes.io/docs/user-guide/secrets/[Secrets] settings.
+The Data Flow Server uses the https://github.com/fabric8io/kubernetes-client[Fabric8 Java client library] to connect to the Kubernetes cluster. We use environment variables to set the values needed when deploying the Data Flow server to Kubernetes. We also use the https://github.com/fabric8io/spring-cloud-kubernetes[Fabric8 Spring Cloud integration with Kubernetes library] to access the Kubernetes https://kubernetes.io/docs/user-guide/configmap/[ConfigMap] and https://kubernetes.io/docs/user-guide/secrets/[Secrets] settings.
 The ConfigMap settings for RabbitMQ are specified in the `src/kubernetes/server/server-config-rabbit.yaml` file and for Kafka in the `src/kubernetes/server/server-config-kafka.yaml` file. MySQL secrets are located in the `src/kubernetes/mysql/mysql-secrets.yaml` file. If you modified the password for MySQL, you should change it in the `src/kubernetes/mysql/mysql-secrets.yaml` file. Any secrets have to be provided in base64 encoding.
 +
 NOTE: We now configure the Data Flow server with file-based security, and the default user is 'user' with a password of 'password'. You should change these values in `src/kubernetes/server/server-config-rabbit.yaml` for RabbitMQ or `src/kubernetes/server/server-config-kafka.yaml` for Kafka.
@@ -319,7 +319,7 @@ NAME         CLUSTER-IP       EXTERNAL-IP       PORT(S)    AGE
 scdf-server  10.103.246.82    130.211.203.246   80/TCP     4m
 ----
 ====
-The URL you need to use is in this case is `http://130.211.203.246`.
+The URL you need to use is in this case is `https://130.211.203.246`.
 +
 If you use Minikube, you do not have an external load balancer and the `EXTERNAL_IP` shows as `<pending>`. You need to use the `NodePort` assigned for the `scdf-server` service. You can use the following command to look up the URL to use:
 +
@@ -327,7 +327,7 @@ If you use Minikube, you do not have an external load balancer and the `EXTERNAL
 [source,bash]
 ----
 $ minikube service --url scdf-server
-http://192.168.99.100:31991
+https://192.168.99.100:31991
 ----
 ====
 
@@ -558,7 +558,7 @@ This section describes how to create streams without using Skipper. To do so:
 ====
 [source,bash,subs=attributes]
 ----
-wget http://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
+wget https://repo.spring.io/{dataflow-version-type-lowercase}/org/springframework/cloud/spring-cloud-dataflow-shell/{dataflow-project-version}/spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 
 java -jar spring-cloud-dataflow-shell-{dataflow-project-version}.jar
 ----
@@ -592,8 +592,8 @@ server-unknown:>
 ====
 [source,bash]
 ----
-server-unknown:>dataflow config server --username user --password password --uri http://130.211.203.246/
-Successfully targeted http://130.211.203.246/
+server-unknown:>dataflow config server --username user --password password --uri https://130.211.203.246/
+Successfully targeted https://130.211.203.246/
 dataflow:>
 ----
 ====
@@ -623,10 +623,10 @@ dataflow:>app register --type sink --name log --uri docker://springcloudstream/l
 Alternatively, if you want register all out-of-the-box stream applications for a particular binder in bulk,
 you can use one of the following commands:
 +
-* RabbitMQ: `dataflow:>app import --uri http://bit.ly/Celsius-SR3-stream-applications-rabbit-docker`
-* Kafka: `dataflow:>app import --uri http://bit.ly/Celsius-SR3-stream-applications-kafka-10-docker`
+* RabbitMQ: `dataflow:>app import --uri https://bit.ly/Celsius-SR3-stream-applications-rabbit-docker`
+* Kafka: `dataflow:>app import --uri https://bit.ly/Celsius-SR3-stream-applications-kafka-10-docker`
 +
-For more details, review how to link:http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/spring-cloud-dataflow-register-apps.html[register applications].
+For more details, review how to link:https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference/html/spring-cloud-dataflow-register-apps.html[register applications].
 
 . Deploy a simple stream in the shell, bu running the following command:
 +
@@ -790,7 +790,7 @@ Now you can look up the URL to use with the following command:
 ----
 dataflow:>! minikube service --url test-http
 command is:minikube service --url test-http
-http://192.168.99.100:32123
+https://192.168.99.100:32123
 ----
 ====
 
@@ -799,7 +799,7 @@ http://192.168.99.100:32123
 ====
 [source,bash]
 ----
-dataflow:>http post --target http://130.211.200.96:8080 --data "Hello"
+dataflow:>http post --target https://130.211.200.96:8080 --data "Hello"
 ----
 ====
 +

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/howto.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/howto.adoc
@@ -6,7 +6,7 @@ This section provides answers to some common "`how do I do that...`" type of que
 that often arise when developers use Spring Cloud Data Flow.
 
 If you have a specific problem that we don't cover here, you might want to check out
-http://stackoverflow.com/tags/spring-cloud-dataflow[stackoverflow.com] to see if someone has
+https://stackoverflow.com/tags/spring-cloud-dataflow[stackoverflow.com] to see if someone has
 already provided an answer. Stack Overflow is also a great place to ask new questions (please use
 the `spring-cloud-dataflow` tag).
 
@@ -16,7 +16,7 @@ can send us a {github-code}[pull request].
 == Logging
 
 Spring Cloud Data Flow is built upon several Spring projects, but ultimately the dataflow-server is a
-Spring Boot app, so the logging techniques that apply to any link:http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-logging[Spring Boot]
+Spring Boot app, so the logging techniques that apply to any link:https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html#howto-logging[Spring Boot]
 application are applicable here as well.
 
 While troubleshooting, the following are the two primary areas where enabling the DEBUG logs could be useful.

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/index.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/index.adoc
@@ -34,9 +34,9 @@ Sabby Anandan, Marius Bogoevici, Eric Bottard, Mark Fisher, Ilayaperumal Gopinat
 :docker-timestamp-task-version: 1.3.1.RELEASE
 :skipper-core-version: 1.1.4.RELEASE
 
-:spring-cloud-dataflow-docs: http://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference
+:spring-cloud-dataflow-docs: https://docs.spring.io/spring-cloud-dataflow/docs/{scdf-core-version}/reference
 :github-repo: spring-cloud/spring-cloud-dataflow-server-kubernetes
-:github-code: http://github.com/{github-repo}
+:github-code: https://github.com/{github-repo}
 :dataflow-asciidoc: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/{scdf-core-git}/spring-cloud-dataflow-docs/src/main/asciidoc
 
 ifdef::backend-html5[]

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/streams-skipper.adoc
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/asciidoc/streams-skipper.adoc
@@ -41,7 +41,7 @@ scdf-server  10.103.246.82    130.211.203.246   80/TCP     4m
 ----
 ====
 
-In the preceding example, the URL to use is http://130.211.203.246
+In the preceding example, the URL to use is https://130.211.203.246
 
 If you use Minikube, you do not have an external load balancer and the EXTERNAL-IP column shows `<pending>`. You need to use the NodePort assigned for the `skipper` service. The following example (with output) shows how to look up the URL to use:
 
@@ -49,7 +49,7 @@ If you use Minikube, you do not have an external load balancer and the EXTERNAL-
 [source]
 ----
 $ minikube service --url scdf-server
-http://192.168.99.100:31991
+https://192.168.99.100:31991
 ----
 ====
 
@@ -58,8 +58,8 @@ The following example (with output) shows how to configure the Data Flow server 
 ====
 [source,console,options=nowrap]
 ----
-server-unknown:>dataflow config server --username user --password password --uri http://130.211.203.246
-Successfully targeted http://130.211.203.246
+server-unknown:>dataflow config server --username user --password password --uri https://130.211.203.246
+Successfully targeted https://130.211.203.246
 dataflow:>
 ----
 ====

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-kubernetes-docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://130.211.203.246/ (AnnotatedConnectException) with 2 occurrences migrated to:  
  https://130.211.203.246/ ([https](https://130.211.203.246/) result AnnotatedConnectException).
* [ ] http://130.211.200.96:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://130.211.200.96:8080 ([https](https://130.211.200.96:8080) result ConnectTimeoutException).
* [ ] http://130.211.203.246 (ConnectTimeoutException) with 4 occurrences migrated to:  
  https://130.211.203.246 ([https](https://130.211.203.246) result ConnectTimeoutException).
* [ ] http://192.168.99.100:31991 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.99.100:31991 ([https](https://192.168.99.100:31991) result ConnectTimeoutException).
* [ ] http://192.168.99.100:32123 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.99.100:32123 ([https](https://192.168.99.100:32123) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-dataflow/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-dataflow/ ([https](https://cloud.spring.io/spring-cloud-dataflow/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-skipper/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-skipper/ ([https](https://cloud.spring.io/spring-cloud-skipper/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/howto-logging.html) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-dataflow-server-kubernetes/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/) result 200).
* [ ] http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/tags/spring-cloud-dataflow with 2 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-cloud-dataflow ([https](https://stackoverflow.com/tags/spring-cloud-dataflow) result 200).
* [ ] http://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes with 2 occurrences migrated to:  
  https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes ([https](https://waffle.io/spring-cloud/spring-cloud-dataflow-server-kubernetes) result 200).
* [ ] http://bit.ly/Celsius-SR3-stream-applications-kafka-10-docker with 1 occurrences migrated to:  
  https://bit.ly/Celsius-SR3-stream-applications-kafka-10-docker ([https](https://bit.ly/Celsius-SR3-stream-applications-kafka-10-docker) result 301).
* [ ] http://bit.ly/Celsius-SR3-stream-applications-rabbit-docker with 1 occurrences migrated to:  
  https://bit.ly/Celsius-SR3-stream-applications-rabbit-docker ([https](https://bit.ly/Celsius-SR3-stream-applications-rabbit-docker) result 301).
* [ ] http://kubernetes.io/docs/user-guide/configmap/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/configmap/ ([https](https://kubernetes.io/docs/user-guide/configmap/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/prereqs/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/prereqs/ ([https](https://kubernetes.io/docs/user-guide/prereqs/) result 301).
* [ ] http://kubernetes.io/docs/user-guide/secrets/ with 1 occurrences migrated to:  
  https://kubernetes.io/docs/user-guide/secrets/ ([https](https://kubernetes.io/docs/user-guide/secrets/) result 301).
* [ ] http://repo.spring.io/ with 1 occurrences migrated to:  
  https://repo.spring.io/ ([https](https://repo.spring.io/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8761/eureka/ with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences